### PR TITLE
Add config file to source secrets from

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.class
+config.properties

--- a/APITesting/APITest.py
+++ b/APITesting/APITest.py
@@ -1,6 +1,7 @@
 import requests
 import yfinance as yf
 import json
+import configparser
 
 
 def delivery_report(err, msg):
@@ -47,7 +48,10 @@ def fetch_updated_yahoo_finance_data():
 
 # Main function
 def main():
-    api_url = "https://api.polygon.io/v2/reference/news?ticker=AAPL&limit=10&apiKey=K_BzBMJ_P99kHEvLjB2cC8lQuEruCpUE"
+    config = configparser.ConfigParser()
+    config.read("Config/config.properties")
+    api_key = config['DEFAULT']['polygon.apikey']
+    api_url = "https://api.polygon.io/v2/reference/news?ticker=AAPL&limit=10&apiKey=" + api_key
     
     
     # Pull data from the API

--- a/Config/ConfigLoader.java
+++ b/Config/ConfigLoader.java
@@ -1,0 +1,37 @@
+package Config;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+public class ConfigLoader {
+
+    /**
+     * Eager creation of ConfigLoader to avoid thread synchronization overhead
+     */
+    private static ConfigLoader instance = new ConfigLoader();
+    private Properties properties;
+
+    public static ConfigLoader getInstance() {
+        return instance;
+    }
+
+    private ConfigLoader() {
+        this.properties = properties;
+        try (FileInputStream input = new FileInputStream("config.properties")) {
+            properties.load(input);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public String getProperty(String propertyKey) {
+        try {
+            return properties.getProperty(propertyKey);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    } 
+}
+

--- a/SocketTesting/UDPServer.java
+++ b/SocketTesting/UDPServer.java
@@ -1,5 +1,6 @@
 package SocketTesting;
 
+import Config.ConfigLoader;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -17,7 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class UDPServer {
 
-    private static final int UDP_PORT = 5005;
+    private static final int UDP_PORT = Integer.parseInt(ConfigLoader.getInstance().getProperty("udp_server.port"));
     private static final int NUM_PROCESSORS = Runtime.getRuntime().availableProcessors();
     private static AtomicBoolean continuePolling = new AtomicBoolean(true);
     private static AtomicInteger messagesConsumed = new AtomicInteger(0);
@@ -31,7 +32,7 @@ public class UDPServer {
     }
 
     static void launchUDPServer() {
-        System.out.println("UDP server up and listening on 127.0.0.1:5005");
+        System.out.println("UDP server up and listening on 127.0.0.1:" + UDP_PORT);
         try {
 
             ExecutorService executorService = launchExecutorService(NUM_PROCESSORS);


### PR DESCRIPTION
- Add singleton Java class with eager instantiation. If lazy instantiation, there is potential for race condition between two threads calling the getInstance() method at the same time. Using the synchronize keyword solves the problem but is expensive.
- Same for Python
- Will be used for API key (unused rn) and IP addresses for Kafka etc