### PR TITLE
Add ingestion microservice/API that will ingest news headlines

### DIFF
--- a/IngestionService/Dockerfile
+++ b/IngestionService/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+# Set work directory
+WORKDIR /app
+
+# Install system dependencies (if needed)
+RUN apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements (create requirements.txt if not present)
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose FastAPI port
+EXPOSE 8000
+
+# Command to run the FastAPI app with uvicorn
+CMD ["uvicorn", "ingestion_service:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/IngestionService/ingestion_service.py
+++ b/IngestionService/ingestion_service.py
@@ -1,0 +1,87 @@
+from fastapi import FastAPI, BackgroundTasks
+from concurrent.futures import ThreadPoolExecutor
+import finnhub
+import time
+import logging
+from pathlib import Path
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(threadName)s] %(name)s: %(message)s"
+)
+logger = logging.getLogger("finnhub_service")
+
+app = FastAPI()
+
+# Globals initialized on startup
+executor: ThreadPoolExecutor | None = None
+finnhub_client: finnhub.Client | None = None
+
+# File that contains tickers (one per line)
+TICKER_FILE = Path("testTickers.txt") # TODO: pull from a central file used by both APIs
+
+# startup event hook that initializes global resources like API client + thread pool
+@app.on_event("startup")
+def on_startup():
+    global executor, finnhub_client
+    executor = ThreadPoolExecutor(max_workers=4)
+    finnhub_client = finnhub.Client(api_key="YOUR_API_KEY") #TODO add in API Key in a secure way to be used in container
+    logger.info("🚀 Executor + Finnhub client initialized")
+
+@app.on_event("shutdown")
+def on_shutdown():
+    global executor
+    if executor:
+        executor.shutdown(wait=True)
+        logger.info("🛑 Executor shut down")
+
+@app.post("/fetch-news")
+def fetch_news(background_tasks: BackgroundTasks):
+    """
+    Endpoint to fetch news for tickers from file.
+    Each request to Finnhub is rate-limited (2s delay).
+    """
+    global executor, finnhub_client
+
+    if not finnhub_client or not executor:
+        logger.error("Service not initialized")
+        return {"error": "Service not initialized"}
+
+    if not TICKER_FILE.exists():
+        logger.error(f"Ticker file not found: {TICKER_FILE}")
+        return {"error": f"Ticker file not found: {TICKER_FILE}"}
+
+    # Load tickers from file
+    tickers = [line.strip() for line in TICKER_FILE.read_text().splitlines() if line.strip()]
+    logger.info(f"📂 Loaded {len(tickers)} tickers from {TICKER_FILE}")
+
+    # Schedule the background task
+    background_tasks.add_task(fetch_and_process_news, tickers)
+
+    return {"status": "submitted", "tickers": tickers}
+
+def fetch_and_process_news(tickers: list[str]):
+    """Fetch and process news for each ticker in the background."""
+    global executor, finnhub_client
+    for i, ticker in enumerate(tickers):
+        try:
+            news = finnhub_client.company_news(
+                ticker,
+                _from="2025-08-20",
+                to="2025-08-27"
+            )
+            executor.submit(process_news, ticker, news)
+            logger.info(f"✅ Submitted {len(news)} news items for {ticker}")
+        except Exception as e:
+            logger.error(f"❌ Error fetching news for {ticker}: {e}")
+        if i < len(tickers) - 1:
+            logger.info("⏳ Waiting 2 seconds before next request...")
+            time.sleep(2)
+
+def process_news(ticker: str, news: list[dict]):
+    """Background work (runs in thread pool)."""
+    logger.info(f"Processing {len(news)} headlines for {ticker}")
+    time.sleep(1)  # simulate work
+    for item in news[:2]:  # just log first 2 headlines
+        logger.info(f"{ticker}: {item.get('headline')}")

--- a/IngestionService/requirements.txt
+++ b/IngestionService/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+finnhub-python

--- a/IngestionService/testTickers.txt
+++ b/IngestionService/testTickers.txt
@@ -1,0 +1,3 @@
+AAPL
+MSFT
+GOOGL


### PR DESCRIPTION
After some consideration, decided to create a separate API just because the Valuations API (in revamped backend) was getting congested.

When triggered, this endpoint submits an API request to FinnHub for each ticker sequentially. It sleeps the fetching thread 2s after each call to ensure the free tier of 60 API calls/min is in play. Once response is received, work is handed off to a separate thread to perform some work [in flux but will likely incorporate some GRPC client that will fetch the inference from a separate inference microservice...]. This way, we parallelize processing work and fetching work at least.

TODO: 
- add in API key in secure fashion
- move tickers list to central file location that can be used by both containers...